### PR TITLE
macos capture group fix; faster canvas encoding.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ export function  checkWebPSupport(): Boolean  {
         return (m[1] === 'Firefox' && m[2] >= 65) || (m[1] === 'Edge' && m[2] >= 18)
     }
 
-    m = navigator.userAgent.match(/OS X\s?\d*_?(?<os>\d+)?.+ Version\/(?<v>\d+\.\d+)/)
+    m = navigator.userAgent.match(/OS X\s?(?<os>\d+)?.+ Version\/(?<v>\d+\.\d+)/)
     if (m) {
         return m.groups.v >= 14 && (m.groups.os || 99) >= 11
     }

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,10 @@ export function  checkWebPSupport(): Boolean  {
 
     m = navigator.userAgent.match(/OS X\s?(?<os>\d+)?.+ Version\/(?<v>\d+\.\d+)/)
     if (m) {
-        return m.groups.v >= 14 && (m.groups.os || 99) >= 11
+        // Intl.ListFormat only works on Safari 14.1+ & MacOS 11+ - nearly the same specifications as WebP support.
+        // See https://caniuse.com/webp & https://caniuse.com/?search=Intl.ListFormat
+        const intl: any = window.Intl || {}
+        return m.groups.v >= 14 && ((m.groups.os || 99) >= 11 || intl.ListFormat != null)
     }
 
     return false

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,8 @@ export function  checkWebPSupport(): Boolean  {
     // Use canvas hack for webkit-based browsers
     // Kudos to Rui Marques: https://stackoverflow.com/a/27232658/7897049
     const e = document.createElement('canvas')
+    e.width = 1
+    e.height = 1
     if (e.toDataURL && e.toDataURL('image/webp').indexOf('data:image/webp') == 0) {
         return true
     }
@@ -16,7 +18,7 @@ export function  checkWebPSupport(): Boolean  {
         return (m[1] === 'Firefox' && m[2] >= 65) || (m[1] === 'Edge' && m[2] >= 18)
     }
 
-    m = navigator.userAgent.match(/OS X\s?(?<os>\d+)?.+ Version\/(?<v>\d+\.\d+)/)
+    m = navigator.userAgent.match(/OS X\s?\d*_?(?<os>\d+)?.+ Version\/(?<v>\d+\.\d+)/)
     if (m) {
         return m.groups.v >= 14 && (m.groups.os || 99) >= 11
     }


### PR DESCRIPTION
fixed the capturing group for mac os. e.g. it was capturing the '10' instead of '15' in `OS X 10_15_7`.
Also resized the canvas to 1x1 and turns out the encoding is way faster this way.
I was battling some race conditions so every ms was important to me.
<img width="731" alt="Bildschirmfoto 2022-08-04 um 4 51 42 PM" src="https://user-images.githubusercontent.com/8287493/182878302-c8041881-3d7b-49d6-8da8-8d8af4e95607.png">
.